### PR TITLE
Default gridonload to "off"

### DIFF
--- a/headsupgrid/hugrid.js
+++ b/headsupgrid/hugrid.js
@@ -141,7 +141,7 @@ function initialCleanUp() {
 
 
   setgridonload = function () {
-    if ( gridonload === 'off') {
+    if ( typeof gridonload === "undefined" || gridonload === 'off') {
       $('#hugridButton').toggleClass('buttonisoff') ;
       $('#hugrid').toggle();
       $('#hugridRows').toggle();


### PR DESCRIPTION
This very small change will prevent js error if gridonload is not set. If gridonload is not set, then the grid will default to being hidden.
