### PR TITLE
Optional padding lines on both sides

### DIFF
--- a/headsupgrid/hugrid.css
+++ b/headsupgrid/hugrid.css
@@ -55,6 +55,9 @@
     opacity:1.0; /*opacity of row line on :hover */
 }
 
+/* Page Paddings */
+#hugrid .padding { position: absolute; border-left: 1px solid #5dff35 !important; }
+
 /* ------------------------------------------------------------------------- */
 /* Fixed Styles (No need to alter the below styles for standard grid needs.) */
 #hugrid {

--- a/headsupgrid/hugrid.js
+++ b/headsupgrid/hugrid.js
@@ -66,6 +66,19 @@
 
     document.body.appendChild(hugridDiv);
 
+	/* Padding on both sides */
+	  console.log(paddingleft);
+	if (paddingleft !== 0) {
+	  linePaddingLeft = document.createElement("div");
+	  linePaddingLeft.className = "mline padding paddingL";
+	  hugridDiv.appendChild(linePaddingLeft);
+	}
+	if (paddingright !== 0) {
+	  linePaddingRight = document.createElement("div");
+	  linePaddingRight.className = "mline padding paddingR";
+	  hugridDiv.appendChild(linePaddingRight);
+	}
+
     /* If Rows */
     if (rowheight !== 0)  {
       /* Row Container */
@@ -112,6 +125,10 @@
     $('#hugrid div.hugcol').css('width', gutterwidth + colUnits);
     $('#hugridRows').css('margin-top', pagetopmargin + 'px');
     $('#hugridRows div.hugrow').css('margin-top', (rowheight - 1) + 'px');
+
+	  /* Paddings CSS */
+	$('#hugrid .paddingL').css({left: paddingleft});
+	$('#hugrid .paddingR').css({right: paddingright});
 
     /* Create hugridUX and button */
     var hugridUX = document.createElement("div");

--- a/headsupgrid/hugrid.js
+++ b/headsupgrid/hugrid.js
@@ -67,16 +67,19 @@
     document.body.appendChild(hugridDiv);
 
 	/* Padding on both sides */
-	  console.log(paddingleft);
-	if (paddingleft !== 0) {
+	try {
 	  linePaddingLeft = document.createElement("div");
 	  linePaddingLeft.className = "mline padding paddingL";
 	  hugridDiv.appendChild(linePaddingLeft);
+		$('#hugrid .paddingL').css({left: paddingleft});
+	  } catch (e) {
 	}
-	if (paddingright !== 0) {
+	try {
 	  linePaddingRight = document.createElement("div");
 	  linePaddingRight.className = "mline padding paddingR";
 	  hugridDiv.appendChild(linePaddingRight);
+		  $('#hugrid .paddingR').css({right: paddingright});
+	  } catch (e) {
 	}
 
     /* If Rows */
@@ -125,10 +128,6 @@
     $('#hugrid div.hugcol').css('width', gutterwidth + colUnits);
     $('#hugridRows').css('margin-top', pagetopmargin + 'px');
     $('#hugridRows div.hugrow').css('margin-top', (rowheight - 1) + 'px');
-
-	  /* Paddings CSS */
-	$('#hugrid .paddingL').css({left: paddingleft});
-	$('#hugrid .paddingR').css({right: paddingright});
 
     /* Create hugridUX and button */
     var hugridUX = document.createElement("div");


### PR DESCRIPTION
The main container often has a padding (e. g. 15px) on both sides, so that there is a gap between the container and the inner elements.
I added the possibility to show these padding, without messing with the columns (position: absolute).
You can add the properties paddingleft and paddingright to activate them.
